### PR TITLE
Added pythong-potr for weechat-otr support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN BUILD_DEPS=" \
 	aspell-libs \
 	aspell-en \
 	&& update-ca-certificates \
+	&& pip3 install --upgrade python-potr \
 	&& WEECHAT_TARBALL="$(curl -sS https://api.github.com/repos/weechat/weechat/releases/latest | jq .tarball_url -r)" \
 	&& curl -sSL $WEECHAT_TARBALL -o /tmp/weechat.tar.gz \
 	&& mkdir -p /tmp/weechat/build \


### PR DESCRIPTION
Weechat Off-the-Record (OTR) (https://weechat.org/scripts/source/otr.py.html/) support requires `python-potr` to be installed. This PR adds that capability.

This only adds a small amount of storage, so I didn't think it should be commented by default, especially since OTR is the most common form of encrypted communication over IRC.
```
weechat-test                   latest              0476fbfbe61f        3 hours ago         138MB
eggbean/weechat                latest              0a9746a014d9        3 days ago          132MB
```